### PR TITLE
Update validateBpayCRN

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,6 @@ var validateBpayCRN = exports.validateBpayCRN = function(input) {
 	
 	input = String(input);
 	
-	return (input.length == 10 && validateLuhnCheckDigit(input));
+	return (input.length >= 2 && input.length <= 20 && validateLuhnCheckDigit(input));
 	
 }


### PR DESCRIPTION
Hey,

Good work with a simple CRN generator. I see your validation function forces 10 digits, but the spec allows 2-20. This PR fixes that.

Fix from forcing 10 digit length to accepting 2-20 digit length.

Thanks,
Lucas.
